### PR TITLE
Bump sonar-maven-plugin from 3.7.0.1746 to 3.8.0.2131

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>3.8.0.2131</sonar-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 
         <!-- Build properties -->
@@ -107,6 +107,8 @@
         <maven-compiler-plugin.encoding>UTF-8</maven-compiler-plugin.encoding>
 
         <!--
+            TODO: Remove this once we verify that sonar-maven-plugin 3.8.0.2131 works
+
             Sonar properties, until version 3.8 of the Maven Sonar Scanner is released.
             As of 2020-09-25 version 3.8 has not been released.
 


### PR DESCRIPTION
Closes #18

We need to verify this works with Sonar, and then address the TODO I added about removing the `sonar.java.source` and `sonar.java.target` properties.