### PR TITLE
Add JUnit Pioneer as test-scoped dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <assertj.version>3.19.0</assertj.version>
         <awaitility.version>4.0.3</awaitility.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
+        <junit-pioneer.version>1.3.8</junit-pioneer.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <mockito.version>3.8.0</mockito.version>
 
@@ -172,6 +173,32 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>${junit-pioneer.version}</version>
+            <scope>test</scope>
+            <!-- Because Pioneer is behind Jupiter's current version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-params</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* Add junit-pioneer 1.3.8. to the POM
* The exclusions are necessary because pioneer is still depending on
  an earlier jupiter version (5.5.2 as I write this)

Closes #14