### PR TITLE
Update to build on JDK 11 and 16, conditional Sonar execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,30 +9,58 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [ '11', '16' ]
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: Set up JDK 11
         uses: actions/setup-java@v2.1.0
         with:
-          java-version: 11
+          java-version: ${{ matrix.java_version }}
           distribution: 'adopt'
           check-latest: true
+
+      # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v2.1.6
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
       - name: Cache Maven packages
         uses: actions/cache@v2.1.6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
+
+      # Compile the project
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        run: mvn -B -V compile
+
+      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      - name: Run tests
+        if: ${{ matrix.java_version != '11' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        run: mvn -B -V verify
+
+      # Run Sonar Analysis (on Java version 11 only)
+      - name: Analyze with SonarCloud
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B package org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -B -V verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar


### PR DESCRIPTION
* Build on JDK 11 and 16
* Only run Sonar analysis when a SONAR_TOKEN exists. This also means
  that PRs submitted by dependabot will NOT trigger Sonar, and thus
  they won't always fail due to a Sonar permissions error.

Closes #49