### PR TITLE
Break apart the release function from the deployment to central function

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: deploy
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  deploy:
+    name: Deploy to Maven Central
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-jdk@v2.3.1
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          check-latest: true
+          server-id: ossrh
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
+
+      - name: Build and Deploy
+        run: mvn -B -V -ntp -DpushToCentral=true deploy
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Cut new release
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-jdk@v2.3.1
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          check-latest: true
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
+
+      - name: Cut Release
+        run: mvn -B -V -ntp release:clean release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -304,10 +304,11 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${maven-release-plugin.version}</version>
                 <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
                     <mavenExecutorId>forked-path</mavenExecutorId>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <arguments>${arguments} -Prelease</arguments>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <preparationGoals>clean test</preparationGoals>
                 </configuration>
             </plugin>
 
@@ -347,13 +348,29 @@
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>deploy</id>
+            <activation>
+                <property>
+                    <name>pushToCentral</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <gpg.keyname><!-- Need to add GPG key --></gpg.keyname>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${maven-gpg-plugin.version}</version>
+                        <!-- This allows GPG to loopback for the passphrase allowing to use the envs -->
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -378,6 +395,10 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                            <notimestamp>true</notimestamp>
+
                             <!-- Make JavaDoc understand the "new" tags introduced in Java 8 (!) -->
                             <tags>
                                 <tag>
@@ -423,6 +444,15 @@
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>nexus-deploy</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This is needed for us to further automate the entire build process.  For now, we will run the new release workflow manually and then that will trigger the deployment workflow (once the release plugin creates the tag).

We still need to register a GPG key and setup all the secrets (probably as organization secrets).

The pom has changes for the release plugin so that the profile that does all the work to push to Nexus is no longer done.  There are also a couple of tweaks to the javadoc, gpg and nexus plugins that matches what Dropwizard does and which makes sense (to me at least) for automation.

Closes #74 