### PR TITLE
Add JShell Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
 
         <!-- Versions for plugins -->
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <jshell-maven-plugin.version>1.3</jshell-maven-plugin.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
@@ -221,6 +222,12 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.johnpoth</groupId>
+                <artifactId>jshell-maven-plugin</artifactId>
+                <version>${jshell-maven-plugin.version}</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Add the jshell-maven-plugin to the POM to make it easy to work with any project in JShell, by adding the project's classpath to JShell.