### PR TITLE
Force lombok plugin to use our lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,13 @@
                         <groupId>org.projectlombok</groupId>
                         <artifactId>lombok-maven-plugin</artifactId>
                         <version>${lombok-maven-plugin.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <execution>
                                 <id>delombok</id>


### PR DESCRIPTION
When trying to release kiwi, received error:

Unable to delombok: InvocationTargetException: Cannot read field "bindingsWhenTrue" because "currentBindings" is null

This is a known error. For more details, see
https://github.com/awhitford/lombok.maven/issues/98