### PR TITLE
Delete working copy of repository created by release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,9 @@
                         These duplicate classes will be seen by IDEs and cause problems.
                         The following ensures we delete the delomboked sources once we
                         no longer need them after generating the javadoc.
+
+                        Also remove the working copy of the repository created by
+                        the Maven Release Plugin.
                     -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -437,7 +440,7 @@
                         <version>${maven-antrun-plugin.version}</version>
                         <executions>
                             <execution>
-                                <id>delete-delombok-generated-sources</id>
+                                <id>delete-unwanted-directories</id>
                                 <phase>verify</phase>  <!-- ensure this executes after javadoc -->
                                 <goals>
                                     <goal>run</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,11 @@
                                 </goals>
                                 <configuration>
                                     <target>
+                                        <!-- Delete the delomboked sources directory -->
                                         <delete dir="${project.build.directory}/generated-sources/delombok" />
+
+                                        <!-- Delete the checkout directory created during the release process -->
+                                        <delete dir="${project.build.directory}/checkout"/>
                                     </target>
                                 </configuration>
                             </execution>
@@ -465,7 +469,7 @@
                         </executions>
                     </plugin>
 
-                    <plugin>
+                    <!--<plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>${nexus-staging-maven-plugin.version}</version>
@@ -475,7 +479,7 @@
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
-                    </plugin>
+                    </plugin>-->
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
                         </executions>
                     </plugin>
 
-                    <!--<plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>${nexus-staging-maven-plugin.version}</version>
@@ -482,7 +482,7 @@
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
-                    </plugin>-->
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Use the maven-antrun-plugin to delete the target/checkout directory, which is the default working copy directory created by the Maven Release Plugin.

Closes #288