### PR TITLE
Update "requireMavenVersion" to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
                             <rules>
                                 <dependencyConvergence />
                                 <requireMavenVersion>
-                                    <version>3.3.9</version>
+                                    <version>3.6.3</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Update the Maven Enforcer plugin's minimum required version from 3.3.9 to 3.6.3. This new version is the version that the versions plugin told me to require when I did a display-plugin-updates. So, that's what I am doing.