### PR TITLE
Increase the Nexus staging timeout from 5 to 15 minutes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Hopefully this will avoid the timeouts I often encounter when releasing libraries.

reference:
https://help.sonatype.com/en/configuring-your-project-for-deployment.html#deployment-with-the-nexus-staging-maven-plugin