### PR TITLE
Add assertj-bom and add assertj-guava as a test-scope dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,14 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>${assertj.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
 
     </dependencyManagement>
@@ -147,7 +155,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-guava</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
* Add assertj-bom in dependency management
* Remove the (now redundant) version from assertj-core
* Add assertj-guava as a test-scoped dependency

Closes #394