### PR TITLE
Add sonar.scanner.skipJreProvisioning to prevent JRE download failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,8 @@
         <!-- TODO: Check if these will be inherited so we can remove them from other repos -->
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <!-- Prevents the scanner from downloading a JRE from SonarCloud CDN, which
+             intermittently fails with HTTP 403. CI already provides Java. -->
         <sonar.scanner.skipJreProvisioning>true</sonar.scanner.skipJreProvisioning>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <!-- TODO: Check if these will be inherited so we can remove them from other repos -->
         <sonar.organization>kiwiproject</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.scanner.skipJreProvisioning>true</sonar.scanner.skipJreProvisioning>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Add sonar.scanner.skipJreProvisioning=true to prevent the Sonar scanner from attempting to download a JRE from SonarCloud's CDN, which intermittently fails with HTTP 403. CI environments already have Java available, making the provisioning step unnecessary.