### PR TITLE
Use Temurin JDK distribution in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v5.2.0
         with:
           java-version: ${{ matrix.java_version }}
-          distribution: 'zulu'
+          distribution: 'temurin'
           check-latest: true
 
       # Cache all the things


### PR DESCRIPTION
Switch the setup-java distribution from zulu to temurin. Temurin LTS distributions are cached on GitHub-hosted runners, avoiding a download on every build.